### PR TITLE
Fix exchange rate formula

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Usage of the do script is:
 1. To get a dev shell, run the following from the root of the project
 
 ```bash
-nix developer
+nix develop
 ```
 
 ## Building

--- a/contract/src/liquid.mligo
+++ b/contract/src/liquid.mligo
@@ -89,7 +89,7 @@ let create_token_if_required (s : liquid_storage) : liquid_storage =
       let after_token_creation = create_evtez_token s in
       mint_to_treasury (base_treasury_tokens, after_token_creation)
     else
-     s
+      s
 
 (* Validates the amount of evXTZ to be redeemed*)
 let validate_redemption ( amount_to_redeem, storage : nat * liquid_storage ) : nat =
@@ -107,11 +107,11 @@ let validate_redemption ( amount_to_redeem, storage : nat * liquid_storage ) : n
 
 (* Calculates the amount of evXTZ to be minted from the required XTZ that is being deposited *)
 let get_amount_to_mint ( a, r : nat * exchange_rate) : nat =
-    (a / r.xtz) * r.evxtz
+    a * r.evxtz / r.xtz
 
 (* Calculates the amount of XTZ to be removed from the treasury due to the amount of evXTZ being burned / redeemed *)
 let get_amount_to_remove_from_treasury ( a, r : nat * exchange_rate) : nat =
-    (a / r.evxtz) * r.xtz
+    a * r.xtz / r.evxtz
 
 
 (* Transfers 'XTZ' to treasury  *)
@@ -122,10 +122,8 @@ let transfer_to_treasury (a, s: nat * liquid_storage) : liquid_storage =
 
 (* Removes 'XTZ' from treasury  *)
 let remove_from_treasury (a, s: nat * liquid_storage) : liquid_storage =
-    let treasury_after_transfer =  { s.treasury with value = abs (s.treasury.value - a) } in
+    let treasury_after_transfer = { s.treasury with value = abs (s.treasury.value - a) } in
     { s with treasury = treasury_after_transfer }
-
-
 
 (* Fake underlying staking rewards to make the fx event more interesting *)
 let adjust_deposit (treasury_amount, deposit_amount: nat * nat)

--- a/contract/src/manager.mligo
+++ b/contract/src/manager.mligo
@@ -64,11 +64,13 @@ let validate_burn_amount (s, n: nat * nat) : nat =
     if new_supply < 0  then
       (failwith insufficient_balance : nat)
     else
-     abs (new_supply)
+      abs (new_supply)
 
 let burn_update_total_supply (txs, total_supplies
     : (mint_burn_tx list) * token_total_supply) : token_total_supply =
-  let update = fun (supplies, tx : token_total_supply * mint_burn_tx) -> validate_burn_amount (supplies, tx.amount) in
+  let update (supplies, tx : token_total_supply * mint_burn_tx) : nat =
+    validate_burn_amount (supplies, tx.amount)
+  in
   List.fold update txs total_supplies
 
 let burn_tokens (param, storage : mint_burn_tx_param * token_storage)


### PR DESCRIPTION
The way to compute the amount to remove from treasury is suffering from truncated integer division. This PR will hopefully resolve the issue of falling exchange rates.