### PR TITLE
Upgrade Kathmandu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ visualizer/pkg
 visualizer/dist
 .vscode
 **/result
+out

--- a/README.md
+++ b/README.md
@@ -83,30 +83,3 @@ nix build .#contract
 ```
 All build outputs will be found under `result/`
 
-
-# Patching the Michelson code
-
-Ligo doesn't currently support event emission so that compiled Michelson code needs to be adjusted to emit the events correctly.  In the resulting compiled code for the liquid contract `liquid.tz` there is a string marker to help narrow down the place that needs to be amended.  In the code one can look for a string "This is the emission function".  The surrounding code should be of the following format:
-
-```Michelson
-         APPLY ;
-         LAMBDA
-           (pair nat nat)
-           unit
-           { CDR ;
-             INT ;
-             ISNAT ;
-             IF_NONE
-               { DROP; PUSH string "This is the emission function" ; FAILWITH }
-               { DROP ; UNIT } } ;
-```
-
-The `(pair nat nat)` is the liquid exchange rate that needs to be emited.  This can be accomplished with the following:
-
-```Michelson
-EMIT %xrate
-```
-Replace `DROP; PUSH string "This is the emission function" ; FAILWITH` with the code above.
-
-Once the compiled code has been patched it can then be deployed.
-

--- a/contract/src/liquid.mligo
+++ b/contract/src/liquid.mligo
@@ -49,8 +49,8 @@ type liquid_param =
   | Redeem of nat
 
 (* Event emission *)
-let emit_event ( _e : event ) : operation =
-    failwith "This is the emission function"
+let emit_event ( e : event ) : operation =
+    Tezos.emit "%xrate" e
 
 
 (* Calculate the current exchange rate from the current information in the treasury and the token storage *)

--- a/do
+++ b/do
@@ -33,7 +33,7 @@ make_out_dir(){
 build_storage() {
     echo "Compiling liquid storage"
     make_out_dir
-    ligo compile contract contract/src/liquid.mligo -e  liquid_main -s cameligo -o out/liquid.tz
+    ligo compile contract contract/src/liquid.mligo -e  liquid_main -s cameligo -o out/liquid.tz --protocol kathmandu
 }
 
 build_contract(){

--- a/visualizer/index.html
+++ b/visualizer/index.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 
 <head>


### PR DESCRIPTION
LIGO now supports Kathmandu primitives. It is time to update the README and source to use the primitives.